### PR TITLE
only need iconv-devel if rhel/centos < 5.4

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,8 +20,8 @@ when 'debian'
 when 'rhel', 'fedora'
   %w(
     readline readline-devel zlib zlib-devel libyaml-devel libffi-devel openssl-devel
-    bzip2 autoconf libtool bison iconv-devel
-  )
+    bzip2 autoconf libtool bison
+  ) + (node.platform_version < '5.4' ? [iconv-devel] : [])
 else
   []
 end


### PR DESCRIPTION
Backwards compatible. 
